### PR TITLE
ci: add merge_group trigger to unblock GitHub merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
     branches: [develop, main]
   pull_request:
     branches: [develop, main]
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,7 @@ on:
     branches: [develop, main]
   pull_request:
     branches: [develop, main]
+  merge_group:
   schedule:
     # Run weekly on Saturdays at 10:26 PM UTC
     - cron: '26 22 * * 6'


### PR DESCRIPTION
## Problem

The merge queue creates temporary `gh-readonly-queue/develop/*` branches when PRs are enqueued. Without the `merge_group` trigger, GitHub Actions never fires on those branches — required checks never report, and the queue times out after 1 hour.

This blocked all three security PRs (#237, #273, #274) from merging despite passing all checks on the PR itself.

## Changes

- Add `merge_group:` trigger to `ci.yml` and `codeql-analysis.yml`
- Remove `ci/circleci: build-and-test` from required status checks (GitHub Actions runs the same suite; CircleCI cannot be triggered on `gh-readonly-queue/*` branches)

## After this lands

Re-add required status checks pointing to the GitHub Actions jobs (`Analyze Code (javascript)`, `✅ All Checks Passed`) which now run on both `pull_request` and `merge_group` events.