### PR TITLE
docs: point the README at green-tea as the successor

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@
 </p>
 
 <br />
+
+> ### Expressive Tea is in maintenance. Its successor is [green-tea](https://github.com/Expressive-Tea/green-tea).
+>
+> green-tea keeps the ideas from this project — decorators, dependency injection, structure — and drops the foundation: no Express, no InversifyJS, and a **dependency graph** as the core instead of a middleware chain. It runs on Node, Deno, Bun and Cloudflare Workers from one codebase.
+>
+> **This was a ceiling, not an abandonment.** Issues [#266](https://github.com/Expressive-Tea/expresive-tea/issues/266), [#267](https://github.com/Expressive-Tea/expresive-tea/issues/267), [#268](https://github.com/Expressive-Tea/expresive-tea/issues/268) and [#269](https://github.com/Expressive-Tea/expresive-tea/issues/269) in this repo are the list that made it obvious: type-safe DI, module-scoped providers, a boot-stage redesign and a type-safety overhaul — four breaking XL changes filed on the same day. That is not a v3. Building on someone else's chain means inheriting their model, and every one of those items ended in *"…but Express won't let me."*
+>
+> Expressive Tea still works, is still published as [`@expressive-tea/core`](https://www.npmjs.com/package/@expressive-tea/core), and still receives security fixes. **For new projects, start with green-tea.**
+
+<br />
 <p align="center">
   <a href="https://github.com/Expressive-Tea/expresive-tea">
     <img src="images/logo.png" alt="Logo" width="160" />


### PR DESCRIPTION
A notice above the fold, after the badges.

### Why

This repo had 24 open issues, every one filed by me on 2026-02-11 in a single planning session. None from the community. From the outside that reads as an abandoned project — and it is the first thing anyone checks when asking whether a maintainer finishes what they start.

They were the opposite of abandonment. Four of them (#266, #267, #268, #269) were type-safe DI, module-scoped providers, a boot-stage redesign and a type-safety overhaul: **four breaking XL changes filed the same day.** That is not a major version. That is a different framework, and it became [green-tea](https://github.com/Expressive-Tea/green-tea).

All 24 are now closed, each with a comment pointing either at how green-tea solved it or at the green-tea issue carrying it forward. This notice tells the same story to anyone who reads the README instead of the issue tracker.

### What it does not say

It does not say this project is dead. Expressive Tea still works, `@expressive-tea/core` is still published and still installed, and it still gets security fixes. The recommendation is only for **new** projects.